### PR TITLE
Better plasma rifle flashing

### DIFF
--- a/zscript/doom1.zc
+++ b/zscript/doom1.zc
@@ -405,7 +405,7 @@ class ZPerkPlasmaRifle : PlasmaRifle
 		PLSG A 1 { A_Lower(); if (zperk_responsive) A_Lower(); }
 		Loop;
 	Fire:
-		PLSF C 1 Bright { A_FirePlasma(); A_Light1(); }
+		PLSF C 1 Bright A_FirePlasma();
 		PLSF D 2 Bright;
 		TNT1 A 0 A_ReFire();
 		PLSF EFE 1 Bright;
@@ -416,7 +416,7 @@ class ZPerkPlasmaRifle : PlasmaRifle
 		"####" DCB 1;
 		Goto Ready;
 	Hold:
-		PLSF E 1 Bright { A_FirePlasma(); A_Light1(); }
+		PLSF E 1 Bright A_FirePlasma();
 		PLSF FE 1 Bright;
 		TNT1 A 0
 		{
@@ -424,7 +424,9 @@ class ZPerkPlasmaRifle : PlasmaRifle
 			return A_Jump(256, "FireReload");
 		}
 		Stop;
-
+	Flash:
+		TNT1 A 2 A_Light1();
+		Goto LightDone;
 	SwapSprites:
 		PKPL A 0; BKPL A 0;
 		Stop;

--- a/zscript/doom2.zc
+++ b/zscript/doom2.zc
@@ -59,16 +59,28 @@ class ZPerkSuperShotgun : SuperShotgun
 	Fire:
 		TNT1 A 0 A_SwapSprites();
 		"####" A 3 { if (zperk_responsive) A_SetTics(0); }
-		"####" A 7 A_FireShotgun2();
+
+		"####" A 5 A_FireShotgun2();
 		"####" "#" 0 { if (zperk_responsive) A_SetTics(3); }
-		"####" BCD 2;
-		"####" E 4 A_CheckReload();
-		"####" F 4 A_OpenShotgun2();
-		"####" GHIJK 2;
-		"####" L 5 A_LoadShotgun2();
-		"####" MNOPQ 2;
-		"####" R 4 A_CloseShotgun2();
-		"####" S 4;
+		"####" BC 3;
+		"####" D 3;
+
+		"####" "#" 0 A_CheckReload();
+		"####" E 5;
+		"####" F 2;
+
+		"####" "#" 0 A_OpenShotgun2();
+		"####" G 2;
+		"####" HIJK 3;
+
+		"####" "#" 0 A_LoadShotgun2();
+		"####" L 2;
+		"####" M 3;
+		"####" NOPQ 2;
+
+		"####" "#" 0 A_CloseShotgun2();
+		"####" RS 3;
+
 		"####" A 5 A_ReFire();
 		Goto Ready;
 	Flash:


### PR DESCRIPTION
Before this, the plasma rifle inherited the flash state from the default plasma rifle, whose flash sprites completely obscured the improved, smoother flash sprites. This PR fixes that.