### PR TITLE
Fix rocket launcher flash desync

### DIFF
--- a/zscript/doom1.zc
+++ b/zscript/doom1.zc
@@ -343,7 +343,7 @@ class ZPerkRocketLauncher : RocketLauncher
 		PKRL A 0 A_ReFire();
 		Goto Ready;
 	Flash:
-		PKRF A 3 Bright A_Light1();
+		PKRF A 2 Bright A_Light1();
 		PKRF B 2 Bright;
 		PKRF C 2 Bright A_Light2();
 		PKRF DE 3 Bright;


### PR DESCRIPTION
This was pointed out by a user on the forums, but I can't seem to find the exact post. Anyway, this fixes the visible desync between the rocket launcher firing state and its flash state.